### PR TITLE
allow domains in input file to have trailing dot

### DIFF
--- a/analyze-result.py
+++ b/analyze-result.py
@@ -45,6 +45,8 @@ with open(args.inputfile) as fp:
                 continue
 
             domain = data["name"].lower()
+            if domain.endswith('.'):
+                domain=domain[:-1]
 
             # parse NODATA response (authority section)
             auth = data["data"]["authorities"]


### PR DESCRIPTION
if the domains in the input file have trailing dots, the output does not show any lying nsec chains because of:

``` 
            # Revert lying boolean if domain and zonecut is not the same
            # This likely means www is delegated and it is possible that no
            # other hostname beside www exist in this www-subzone.
            if domain != zonecut:
                is_lying_nsec = False
```

with trailing dots this check compares for example "example.com." with zonecut "example.com" and always reverts the previously detected NSEC lie.